### PR TITLE
Returning 1 instead of the value of NaN

### DIFF
--- a/src/scripts/axes/step-axis.js
+++ b/src/scripts/axes/step-axis.js
@@ -28,7 +28,9 @@
   }
 
   function projectValue(value, index) {
-    return this.stepLength * index;
+    var val = this.stepLength * index;
+    //check to see if isNaN;
+    return val !== val ? 1 : val;
   }
 
   Chartist.StepAxis = Chartist.Axis.extend({


### PR DESCRIPTION
When displaying a line chart with one data point the initial position cannot be determined. The projectValue function returns a NaN which the svg cannot be drawn correctly as NaN is not valid for the x1,x2 values on the svg line object.